### PR TITLE
Send a 404 when a meta query returns no results

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -61,7 +61,11 @@ app.get('/taxon', async (req: any, res) => {
     const data = await getTaxonInfo(req.query['name']);
     res.send(data);
   } catch (e: any) {
-    res.status(500).send(e);
+    if (e.status === 404) {
+      res.status(e.status).send(e.message);
+    } else {
+      res.status(500).send(e.message);
+    }
   }
 });
 
@@ -72,7 +76,11 @@ app.get('/organisation', async (req: any, res) => {
     const data = await getOrganisationInfo(req.query['name']);
     res.send(data);
   } catch (e: any) {
-    res.status(500).send(e);
+    if (e.status === 404) {
+      res.status(e.status).send(e.message);
+    } else {
+      res.status(500).send(e.message);
+    }
   }
 });
 
@@ -83,7 +91,11 @@ app.get('/role', async (req: any, res) => {
     const data = await getRoleInfo(req.query['name']);
     res.send(data);
   } catch (e: any) {
-    res.status(500).send(e);
+    if (e.status === 404) {
+      res.status(e.status).send(e.message);
+    } else {
+      res.status(500).send(e.message);
+    }
   }
 });
 
@@ -94,7 +106,11 @@ app.get('/bank-holiday', async (req: any, res) => {
     const data = await getBankHolidayInfo(req.query['name']);
     res.send(data);
   } catch (e: any) {
-    res.status(500).send(e);
+    if (e.status === 404) {
+      res.status(e.status).send(e.message);
+    } else {
+      res.status(500).send(e.message);
+    }
   }
 });
 
@@ -105,7 +121,11 @@ app.get('/person', async (req: any, res) => {
     const data = await getPersonInfo(req.query['name']);
     res.send(data);
   } catch (e: any) {
-    res.status(500).send(e);
+    if (e.status === 404) {
+      res.status(e.status).send(e.message);
+    } else {
+      res.status(500).send(e.message);
+    }
   }
 });
 

--- a/neo4j.ts
+++ b/neo4j.ts
@@ -79,6 +79,12 @@ const getTaxonInfo: GetTaxonInfoSignature = async function(name) {
     }
   ];
   const taxonInfo: Neo4jResponse = await sendCypherQuery(query, 5000);
+  if (taxonInfo.results[0].data.length === 0) {
+    throw {
+      status: 404,
+      message: `No taxon with name "${name}"`
+    };
+  }
   const result: Taxon = {
     type: MetaResultType.Taxon,
     name,
@@ -150,6 +156,12 @@ const getOrganisationInfo: GetOrganisationInfoSignature = async function(name) {
     }
   ];
   const orgInfo: Neo4jResponse = await sendCypherQuery(query, 5000);
+  if (orgInfo.results[0].data.length === 0) {
+    throw {
+      status: 404,
+      message: `No organisation with name "${name}"`
+    };
+  }
   const orgDetails = orgInfo.results[0].data[0].row;
   const personRoleDetails = orgInfo.results[1].data;
   const childDetails = orgInfo.results[2].data;
@@ -195,6 +207,12 @@ const getRoleInfo: GetRoleInfoSignature = async function(name) {
     }
   ];
   const roleInfo: Neo4jResponse = await sendCypherQuery(query, 5000);
+  if (roleInfo.results[0].data.length === 0) {
+    throw {
+      status: 404,
+      message: `No organisation with name "${name}"`
+    };
+  }
   const role = roleInfo.results[0].data[0];
   const persons = roleInfo.results[1];
   const orgs = roleInfo.results[2];
@@ -230,6 +248,12 @@ const getPersonInfo: GetPersonInfoSignature = async function(name) {
     }
   ];
   const personInfo: Neo4jResponse = await sendCypherQuery(query, 5000);
+  if (personInfo.results[0].data.length === 0) {
+    throw {
+      status: 404,
+      message: `No person with name "${name}"`
+    };
+  }
   const result: Person = {
     type: MetaResultType.Person,
     name,
@@ -266,6 +290,12 @@ const getBankHolidayInfo: GetBankHolidayInfoSignature = async function(name) {
     }
   ];
   const bankHolidayInfo: Neo4jResponse = await sendCypherQuery(query, 5000);
+  if (bankHolidayInfo.results[0].data.length === 0) {
+    throw {
+      status: 404,
+      message: `No bank holiday with name "${name}"`
+    };
+  }
   const result: BankHoliday = {
     type: MetaResultType.BankHoliday,
     name,


### PR DESCRIPTION
A meta-search with an exact name should always return a result, since the name is returned from the previous govgraph search.  However we never know what might happen (in particular the Cypher query might fail) so we need to handle errors. In this case, when the query returns no result the API sends back a 404 instead of a 500 so that the UI doesn't freeze but instead just doesn't show the meta box.