### PR TITLE
Handle when there were more than 2 previous holders

### DIFF
--- a/src/ts/view/view-metabox.ts
+++ b/src/ts/view/view-metabox.ts
@@ -82,7 +82,7 @@ const viewRolePersons = (persons: any[]) => {
     case 1: return `
       <p class="govuk-body">Previous holder: ${formatPerson(previous[0])}</p>
     `; break;
-    case 2: return `
+    default: return `
       <details class="govuk-details">
         <summary class="govuk-details__summary">
           <span class="govuk-details__summary-text">Previous holders</span>


### PR DESCRIPTION
When the conditional expression was turned into a switch only cases 0, 1 and 2 were handled, but not > 2. This commit fixes it.