### PR TITLE
Use page views instead of pagerank

### DIFF
--- a/bigquery.ts
+++ b/bigquery.ts
@@ -293,7 +293,7 @@ const buildSqlQuery = function(searchParams: SearchParams, keywords: string[], e
       public_updated_at,
       withdrawn_at,
       withdrawn_explanation,
-      pagerank,
+      page_views,
       taxons,
       primary_organisation,
       organisations AS all_organisations

--- a/csv.ts
+++ b/csv.ts
@@ -48,9 +48,9 @@ const csvFieldFormatters: Record<string, any> = {
     name: 'All publishing organisations',
     format: formatNames
   },
-  'pagerank': {
-    name: 'Popularity',
-    format: (val: string):string => val ? parseFloat(val).toFixed(2) : 'n/a'
+  'page_views': {
+    name: 'Page views',
+    format: (val: string):string => val ? parseInt(val).toString() : '<5'
   },
   'withdrawn_at': {
     name: 'Withdrawn at',
@@ -93,7 +93,7 @@ const makeHeaders = function(obj:Record<string, any>) {
 const formatForCsv = function(lines:any) {
   const headers = makeHeaders(lines[0])
   const body = lines
-    .sort((a:any, b:any) => parseFloat(b.pagerank) - parseFloat(a.pagerank))
+    .sort((a:any, b:any) => parseInt(b.page_views) - parseInt(a.page_views))
     .map((record:any) => {
       const formattedRowObj:any = {}
       for (const [key, value] of Object.entries(record)) {

--- a/cypress/e2e/facets.cy.ts
+++ b/cypress/e2e/facets.cy.ts
@@ -71,8 +71,8 @@ describe('Search results facets', () => {
     cy.get('td:eq(8)').then($th => cy.expect($th.text()).to.match(dateRegexOrNotWithdrawn));
     cy.get('input#show-field-withdrawn_explanation').check();
     cy.get('td:eq(9)').then($th => cy.expect($th.text()).to.not.equal('null'));
-    cy.get('input#show-field-pagerank').check();
-    cy.get('td:eq(10)').then($th => cy.expect($th.text()).to.match(/^[0-9]\d*(\.\d+)?$/));
+    cy.get('input#show-field-page_views').check();
+    cy.get('td:eq(10)').then($th => cy.expect($th.text()).to.match(/^\d+?$/));
     cy.get('input#show-field-taxons').check();
     cy.get('td:eq(11)').then($th => cy.expect($th.text()).to.not.equal('null'));
     cy.get('input#show-field-primary_organisation').check();

--- a/src/ts/events.ts
+++ b/src/ts/events.ts
@@ -90,7 +90,7 @@ const handleEvent: SearchApiCallback = async function(event) {
       state.waiting = true;
       break;
     case EventType.SearchApiCallbackOk:
-      state.searchResults = event.results?.main.sort((a: any, b: any) => b.pagerank - a.pagerank);
+      state.searchResults = event.results?.main.sort((a: any, b: any) => b.page_views - a.page_views);
       state.metaSearchResults = event.results?.meta;
       state.waiting = false;
       state.systemErrorText = null;

--- a/src/ts/view/view.ts
+++ b/src/ts/view/view.ts
@@ -337,9 +337,9 @@ const fieldFormatters: Record<string, any> = {
     name: 'All publishing organisations',
     format: formatNames
   },
-  'pagerank': {
-    name: 'Popularity',
-    format: (val: string) => val ? parseFloat(val).toFixed(2) : 'n/a'
+  'page_views': {
+    name: 'Page views',
+    format: (val: string) => val ? parseInt(val).toString() : '<5'
   },
   'withdrawn_at': {
     name: 'Withdrawn at',


### PR DESCRIPTION
See https://github.com/alphagov/govuk-knowledge-graph-gcp/pull/431

Users are confused about pagerank and assume that the statistic is
derived from the number of page views. We think that the number of page
views will be just as useful for ranking search results.
