### PR TITLE
Lower the limit of number of results

### DIFF
--- a/bigquery.ts
+++ b/bigquery.ts
@@ -308,7 +308,9 @@ const buildSqlQuery = function(searchParams: SearchParams, keywords: string[], e
     ${organisationClause}
     ${linkClause}
 
-    LIMIT 50000
+    ORDER BY page_views DESC
+
+    LIMIT 10000
   `;
 };
 

--- a/src/ts/view/view.ts
+++ b/src/ts/view/view.ts
@@ -230,7 +230,7 @@ const viewResults = function() {
     const html = [];
     const nbRecords = state.searchResults.length;
 
-    if (nbRecords < 50000) {
+    if (nbRecords < 10000) {
       html.push(`
         <h1 tabindex="0" id="results-heading" class="govuk-heading-l">${nbRecords} result${nbRecords !== 0 ? 's' : ''}</h1>`);
     } else {
@@ -239,7 +239,7 @@ const viewResults = function() {
           <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
           <strong class="govuk-warning-text__text">
             <span class="govuk-warning-text__assistive">Warning</span>
-            There are more than 50000 results. Try to narrow down your search.
+            There are more than 10000 results. Try to narrow down your search.
           </strong>
         </div>
       `);


### PR DESCRIPTION
The app was crashing for the query `"tribunal decision"` in Cloud Run,
but not when being run locally.  We tried increasing the memory of the
Cloud Run virtual machines from 512MB to 32GB, which didn't help. Then
we tried lowering the limit of the number of results to 1000, which did
work.  Users have previously requested more than 1000 results, so we
then tested a limit of 10,000, which also worked.

There were a couple of different error messages.  One was that a JSON
document was incomplete, and the other was that `Service Unavailable`
isn't valid JSON.

The whole thing is pretty strange, because the queries worked when
running the app on a laptop, querying BigQuery in production.

We also noticed that the results weren't being ordered by descending
number of page views in the query, only in the front end.  That means
that when there were more results than the 50k limit, an arbitrary set
of pages was sent to the app, and then the app sorted them by descending
number of page views.  That bug would be even worse with a lower limit
to the number of pages returned, so this commit introduces `ORDER BY
page_views DESC` in the BigQuery query, so that only relevant pages are
sent to the front end.
