### PR TITLE
Disable organisation search button

### DIFF
--- a/src/ts/view/view.ts
+++ b/src/ts/view/view.ts
@@ -67,7 +67,9 @@ const viewSearchTypeSelector = () => `
       Search for:
       <button class="${state.searchParams.searchType === 'keyword' ? 'active' : ''}" id="search-keyword">Keywords</button>
       <button class="${state.searchParams.searchType === 'link' ? 'active' : ''}" id="search-link">Links</button>
-      <button class="${state.searchParams.searchType === 'organisation' ? 'active' : ''}" id="search-organisation">Organisations</button>
+      <!-- Org search is disabled until we have tested a new design with users
+        <button class="${state.searchParams.searchType === 'organisation' ? 'active' : ''}" id="search-organisation">Organisations</button>
+      -->
       <button class="${state.searchParams.searchType === 'taxon' ? 'active' : ''}" id="search-taxon">Taxons</button>
       <button class="${state.searchParams.searchType === 'language' ? 'active' : ''}" id="search-language">Languages</button>
       <button class="${state.searchParams.searchType === 'mixed' ? 'active' : ''}" id="search-mixed">Mixed</button>


### PR DESCRIPTION
User testing showed that users are sometimes confused by the tabs, so we
won't introduce the new "Organisations" tab until we have tested a new
design.  This commit only removes the display of the tab, but leaves the
API functionality intact.
