### PR TITLE
New feature: expand abbreviations

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -1,6 +1,6 @@
 // Import the express in typescript file
 import express from 'express';
-import { sendSearchQuery, sendInitQuery, getOrganisationInfo, getPersonInfo, getRoleInfo, getTaxonInfo, getBankHolidayInfo, getTransactionInfo } from './bigquery';
+import { sendSearchQuery, sendInitQuery, getOrganisationInfo, getPersonInfo, getRoleInfo, getTaxonInfo, getBankHolidayInfo, getTransactionInfo, getAbbreviationTextInfo } from './bigquery';
 import { SearchArea, Combinator, SearchType, SearchParams } from './src/ts/search-api-types';
 import { csvStringify } from './csv';
 
@@ -154,6 +154,17 @@ app.get('/person', async (req: any, res) => {
   console.log('API call to /person', req.query);
   try {
     const data = await getPersonInfo(req.query['name']);
+    res.send(data);
+  } catch (e: any) {
+    res.status(500).send(e);
+  }
+});
+
+
+app.get('/abbreviation-text', async (req: any, res) => {
+  console.log('API call to /abbreviation-text', req.query);
+  try {
+    const data = await getAbbreviationTextInfo(req.query['name']);
     res.send(data);
   } catch (e: any) {
     res.status(500).send(e);

--- a/cypress/e2e/infobox.cy.ts
+++ b/cypress/e2e/infobox.cy.ts
@@ -36,4 +36,11 @@ describe('Infobox results', () => {
     cy.contains('div.meta-results-panel p', 'Online government service');
   });
 
+  it('Shows the AbbreviationText infobox', () => {
+    cy.visit('?selected-words=%22MOD%22&search-in-text=false')
+    cy.contains('div.meta-results-panel h2', 'MOD');
+    cy.contains('div.meta-results-panel p', 'stands for');
+    cy.contains('div.meta-results-panel p', 'Ministry of Defence');
+  });
+
 });

--- a/src/ts/search-api-types.ts
+++ b/src/ts/search-api-types.ts
@@ -38,6 +38,7 @@ export type SearchParams = {
 }
 
 export enum MetaResultType {
+  AbbreviationText = "AbbreviationText",
   Person = "Person",
   Organisation = "Organisation",
   BankHoliday = "BankHoliday",
@@ -46,7 +47,14 @@ export enum MetaResultType {
   Transaction = "Transaction"
 }
 
-export type MetaResult = Person | Organisation | BankHoliday | Transaction | Role | Taxon
+
+export type MetaResult = Person | Organisation | BankHoliday | Transaction | Role | Taxon | AbbreviationText
+
+export type AbbreviationText = {
+  type: MetaResultType,
+  abbreviation_titles: string[],
+  abbreviation_text: string
+}
 
 export type Person = {
   type: MetaResultType,

--- a/src/ts/search-api.ts
+++ b/src/ts/search-api.ts
@@ -85,6 +85,9 @@ const buildMetaboxInfo = async function(info: any) {
   console.log(`Found a ${info.type}. Running extra queries`);
   console.log(info);
   switch (info.type) {
+    case 'AbbreviationText': {
+      return await fetchWithTimeout(`/abbreviation-text?name=${encodeURIComponent(info.name)}`);
+    }
     case 'BankHoliday': {
       return await fetchWithTimeout(`/bank-holiday?name=${encodeURIComponent(info.name)}`);
     }

--- a/src/ts/view/view-metabox.ts
+++ b/src/ts/view/view-metabox.ts
@@ -1,6 +1,6 @@
 import { state } from '../state';
 import { viewMetaLink } from './view-components';
-import { MetaResultType, Taxon, Organisation, Person, Role, Transaction, BankHoliday } from '../search-api-types';
+import { MetaResultType, Taxon, Organisation, Person, Role, AbbreviationText, Transaction, BankHoliday } from '../search-api-types';
 
 
 const viewDetails = (title: string, list: any[], itemFormatFn: (item: any) => string): string => {
@@ -204,6 +204,17 @@ const viewMetaLinkList = (names: string[], title?: string, noneTitle?: string): 
 };
 
 
+const viewAbbreviationText = (record: AbbreviationText): string => `
+  <div class="meta-results-panel">
+    <h2 class="govuk-heading-m">${record.abbreviation_text}</h2>
+    <p class="govuk-body">stands for</p>
+    <ul class="govuk-list govuk-list--bullet">
+      ${record.abbreviation_titles.map(title => `<li>${viewMetaLink(title)}</li>`).join('')}
+    </ul>
+  </div>
+`;
+
+
 const viewTransaction = (record: Transaction): string =>
   `<div class="meta-results-panel">
      <h2 class="govuk-heading-m">
@@ -285,6 +296,7 @@ const viewMetaResults = function(): string {
 
   const record = state.metaSearchResults[0];
   switch (record.type) {
+    case 'AbbreviationText': return viewAbbreviationText(record);
     case 'BankHoliday': return viewBankHoliday(record);
     case 'Organisation': return viewOrg(record);
     case 'Person': return viewPerson(record);


### PR DESCRIPTION
The backend database now includes information on abbreviations found on gov.uk (i.e. `<abbr>`) HTML tags. So a search can check if the keywords typed include one of the known abbreviations (e.g. MOD or HMRC) and display information about it in the infobox.