### PR TITLE
Convert curly double quotes into ASCII double quotes

### DIFF
--- a/src/ts/search-api.ts
+++ b/src/ts/search-api.ts
@@ -48,6 +48,7 @@ const fetchWithTimeout = async function(url: string, timeoutSeconds: number = 60
 const queryBackend: (searchParams: SearchParams, callback: SearchApiCallback) => Promise<void> = async function(searchParams, callback) {
   callback({ type: EventType.SearchRunning });
   const url = `/search?${makeQueryString(searchParams)}`;
+  searchParams.selectedWords = searchParams.selectedWords.replace(/[“”]/g,'"');
   let apiResults: SearchResults;
   try {
     apiResults = await fetchWithTimeout(url, 300);


### PR DESCRIPTION
This is because using curly quotes (as happens when a user sometimes copies and paste search terms) will not have the expected effect to group words into a single keyword.