### PR TITLE
add to fix query description issue

### DIFF
--- a/bigquery.ts
+++ b/bigquery.ts
@@ -141,7 +141,7 @@ const getPersonInfo = async function(name: string): Promise<Person[]> {
   );
 };
 
-
+//keywords as used here must be exactly the same set of combinedWords as used by the function containDescription.
 const sendSearchQuery = async function(searchParams: SearchParams): Promise<SearchResults> {
   const keywords = splitKeywords(searchParams.selectedWords);
   const excludedKeywords = splitKeywords(searchParams.excludedWords);

--- a/cypress/e2e/keywords.cy.ts
+++ b/cypress/e2e/keywords.cy.ts
@@ -15,6 +15,21 @@ describe('Keyword searching', () => {
     cy.get('#results-heading', { timeout: 60000 }).contains('No results');
     cy.title().should('eq', 'GOV.UK pages that contain "wwekufsskjfdksufweuf" - Gov Search')
   });
+   //Added to ensure Uk keyword is being searched
+  it('returns results when searching for keywords that includes Uk and Bahrain', () => {
+    cy.visit('');
+    cy.get('input#keyword').type('Uk and Bahrain');
+    cy.get('button#search').click();
+    cy.contains('button', 'Searching');
+    cy.get('#results-heading', { timeout: 60000 }).contains(/^\d+ results$/);
+    cy.get('#results-heading').then(heading => {
+      numUnfilteredResults = parseInt(heading.text().match(/^(\d+) results$/)[1]);
+    });
+    cy.contains('for pages that contain');
+    cy.contains('Showing results 1 to 10, in descending popularity');
+    cy.get('#results-table');
+    cy.title().should('eq', 'GOV.UK pages that contain "Uk" and "Bahrain" - Gov Search')
+  });
 
   it('returns results when searching for keywords that exist', () => {
     cy.visit('');

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -98,9 +98,9 @@ const containDescription = (search: SearchParams, includeMarkup: boolean) => {
   } else {
     where = 'in their body content';
   }
-  let combineOp = search.combinator === 'all' ? 'and' : 'or';
-  let combinedWords = splitKeywords(search.selectedWords)
-    .filter(w => w.length > 2)
+  const combineOp = search.combinator === 'all' ? 'and' : 'or';
+  // splitKeywords functions is being used in sendSearchQuery to determine bigquery keywords
+  const combinedWords = splitKeywords(search.selectedWords)
     .map(w => makeBold(w, includeMarkup))
     .join(` ${combineOp} `);
   return search.selectedWords !== '' ? `${combinedWords} ${where}` : '';

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -88,7 +88,7 @@ const queryDescription = (search: SearchParams, includeMarkup = true) => {
   return `pages that ${joinedClauses}`;
 };
 
-
+//combinedWords as used here must be exactly the same set of keywords as the ones submitted to BigQuery by the function sendSearchQuery.
 const containDescription = (search: SearchParams, includeMarkup: boolean) => {
   let where: string;
   if (search.whereToSearch.title && search.whereToSearch.text) {
@@ -99,7 +99,6 @@ const containDescription = (search: SearchParams, includeMarkup: boolean) => {
     where = 'in their body content';
   }
   const combineOp = search.combinator === 'all' ? 'and' : 'or';
-  // splitKeywords functions is being used in sendSearchQuery to determine bigquery keywords
   const combinedWords = splitKeywords(search.selectedWords)
     .map(w => makeBold(w, includeMarkup))
     .join(` ${combineOp} `);


### PR DESCRIPTION
WHAT
The query description displays wrongly on search.
WHY
Users could or would be easily confused with the currently displayed description.
HOW
Fix to display the full and readable description of search queries.
cypress test runs successfully
![Screenshot 2023-05-25 at 15 57 06](https://github.com/alphagov/govuk-knowledge-graph-search/assets/12907460/9710cd97-0753-4fb3-baa9-18fa208269a1)
