### PR TITLE
2249 allow partial matching for all links in search

### DIFF
--- a/bigquery.ts
+++ b/bigquery.ts
@@ -365,6 +365,7 @@ const buildSqlQuery = function (
 };
 
 export {
+  buildSqlQuery,
   getBankHolidayInfo,
   getTransactionInfo,
   getOrganisationInfo,

--- a/bigquery.ts
+++ b/bigquery.ts
@@ -1,30 +1,46 @@
-import { Transaction, Taxon, Organisation, Person, Role, MetaResultType, MetaResult, MainResult, SearchParams, Combinator, SearchResults, SearchType, InitResults, BankHoliday } from './src/ts/search-api-types';
-import { splitKeywords } from './src/ts/utils';
-import { languageCode } from './src/ts/lang';
-const { BigQuery } = require('@google-cloud/bigquery');
+import {
+  Transaction,
+  Taxon,
+  Organisation,
+  Person,
+  Role,
+  MetaResultType,
+  MetaResult,
+  MainResult,
+  SearchParams,
+  Combinator,
+  SearchResults,
+  SearchType,
+  InitResults,
+  BankHoliday,
+} from "./src/ts/search-api-types";
+import { splitKeywords } from "./src/ts/utils";
+import { languageCode } from "./src/ts/lang";
+const { BigQuery } = require("@google-cloud/bigquery");
 
 //====== private ======
 
 const internalLinkRegExp = /^((https:\/\/)?((www\.)?gov\.uk))?\//;
 
-
 const bigquery = new BigQuery({
-  projectId: process.env.PROJECT_ID
+  projectId: process.env.PROJECT_ID,
 });
 
-
-const bigQuery = async function(userQuery: string, options?: any) {
+const bigQuery = async function (userQuery: string, options?: any) {
   const params: Record<string, string> = {};
 
   if (options) {
     if (options.keywords) {
-      options.keywords.forEach((keyword: string, index: number) =>
-        params[`keyword${index}`] = keyword
+      options.keywords.forEach(
+        (keyword: string, index: number) =>
+          (params[`keyword${index}`] = keyword)
       );
     }
     if (options.excludedKeywords) {
-      options.excludedKeywords.forEach((keyword: string, index: number) =>
-        params[`excluded_keyword${index}`] = keyword);
+      options.excludedKeywords.forEach(
+        (keyword: string, index: number) =>
+          (params[`excluded_keyword${index}`] = keyword)
+      );
     }
     if (options.name) {
       params.name = options.name;
@@ -48,8 +64,8 @@ const bigQuery = async function(userQuery: string, options?: any) {
 
   const bqOptions = {
     query: userQuery,
-    location: 'europe-west2',
-    params
+    location: "europe-west2",
+    params,
   };
 
   const [rows] = await bigquery.query(bqOptions);
@@ -59,10 +75,10 @@ const bigQuery = async function(userQuery: string, options?: any) {
 
 //====== public ======
 
-const sendInitQuery = async function(): Promise<InitResults> {
+const sendInitQuery = async function (): Promise<InitResults> {
   let bqLocales: any, bqTaxons: any, bqOrganisations: any;
   try {
-    [ bqLocales, bqTaxons, bqOrganisations ] = await Promise.all([
+    [bqLocales, bqTaxons, bqOrganisations] = await Promise.all([
       bigQuery(`
         SELECT DISTINCT locale
         FROM \`content.locale\`
@@ -74,87 +90,112 @@ const sendInitQuery = async function(): Promise<InitResults> {
       bigQuery(`
         SELECT DISTINCT title
         FROM \`graph.organisation\`
-        `)
+        `),
     ]);
-  } catch(e) {
-    console.log('sendInitQueryError', e);
+  } catch (e) {
+    console.log("sendInitQueryError", e);
   }
 
   return {
-    locales: ['', 'en', 'cy'].concat(
+    locales: ["", "en", "cy"].concat(
       bqLocales
         .map((row: any) => row.locale)
-        .filter((locale: string) => locale !== 'en' && locale !== 'cy')
-      ),
+        .filter((locale: string) => locale !== "en" && locale !== "cy")
+    ),
     taxons: bqTaxons.map((taxon: any) => taxon.title),
-    organisations: bqOrganisations.map((organisation: any) => organisation.title)
+    organisations: bqOrganisations.map(
+      (organisation: any) => organisation.title
+    ),
   };
 };
 
-
-const getTaxonInfo = async function(name: string): Promise<Taxon[]> {
+const getTaxonInfo = async function (name: string): Promise<Taxon[]> {
   return await bigQuery(
-    `SELECT "Taxon" as type, * FROM search.taxon WHERE lower(name) = lower(@name);`, { name }
+    `SELECT "Taxon" as type, * FROM search.taxon WHERE lower(name) = lower(@name);`,
+    { name }
   );
 };
 
-
-const getOrganisationInfo = async function(name: string): Promise<Organisation[]> {
+const getOrganisationInfo = async function (
+  name: string
+): Promise<Organisation[]> {
   return await bigQuery(
-    `SELECT "Organisation" as type, * FROM search.organisation WHERE lower(name) = lower(@name);`, { name }
+    `SELECT "Organisation" as type, * FROM search.organisation WHERE lower(name) = lower(@name);`,
+    { name }
   );
 };
 
-
-const getBankHolidayInfo = async function(name: string): Promise<BankHoliday[]> {
+const getBankHolidayInfo = async function (
+  name: string
+): Promise<BankHoliday[]> {
   const bqBankHolidays: BankHoliday[] = await bigQuery(
-    `SELECT * FROM search.bank_holiday WHERE lower(name) = lower(@name);`, { name }
+    `SELECT * FROM search.bank_holiday WHERE lower(name) = lower(@name);`,
+    { name }
   );
   return bqBankHolidays.map((bqBankHoliday: BankHoliday) => {
     return {
       type: MetaResultType.BankHoliday,
       name: bqBankHoliday.name,
       dates: bqBankHoliday.dates.map((date: any) => date.value),
-      divisions: bqBankHoliday.divisions
-    }
+      divisions: bqBankHoliday.divisions,
+    };
   });
 };
 
-
-const getTransactionInfo = async function(name: string): Promise<Transaction[]> {
+const getTransactionInfo = async function (
+  name: string
+): Promise<Transaction[]> {
   return await bigQuery(
-    `SELECT "Transaction" as type, * FROM search.transaction WHERE lower(name) = lower(@name);`, { name }
+    `SELECT "Transaction" as type, * FROM search.transaction WHERE lower(name) = lower(@name);`,
+    { name }
   );
 };
 
-
-const getRoleInfo = async function(name: string): Promise<Role[]> {
+const getRoleInfo = async function (name: string): Promise<Role[]> {
   return await bigQuery(
-    `SELECT "Role" as type, * FROM search.role WHERE lower(name) = lower(@name);`, { name }
+    `SELECT "Role" as type, * FROM search.role WHERE lower(name) = lower(@name);`,
+    { name }
   );
 };
 
-
-const getPersonInfo = async function(name: string): Promise<Person[]> {
+const getPersonInfo = async function (name: string): Promise<Person[]> {
   return await bigQuery(
-    `SELECT "Person" as type, * FROM search.person WHERE lower(name) = lower(@name);`, { name }
+    `SELECT "Person" as type, * FROM search.person WHERE lower(name) = lower(@name);`,
+    { name }
   );
 };
 
 //keywords as used here must be exactly the same set of combinedWords as used by the function containDescription.
-const sendSearchQuery = async function(searchParams: SearchParams): Promise<SearchResults> {
+const sendSearchQuery = async function (
+  searchParams: SearchParams
+): Promise<SearchResults> {
   const keywords = splitKeywords(searchParams.selectedWords);
   const excludedKeywords = splitKeywords(searchParams.excludedWords);
   const query = buildSqlQuery(searchParams, keywords, excludedKeywords);
   const locale = languageCode(searchParams.selectedLocale);
   const taxon = searchParams.selectedTaxon;
   const organisation = searchParams.selectedOrganisation;
-  const selectedWordsWithoutQuotes = searchParams.selectedWords.replace(/"/g, '');
-  const link = searchParams.linkSearchUrl && internalLinkRegExp.test(searchParams.linkSearchUrl)
-    ? searchParams.linkSearchUrl.replace(internalLinkRegExp, 'https://www.gov.uk/')
-    : searchParams.linkSearchUrl;
+  const selectedWordsWithoutQuotes = searchParams.selectedWords.replace(
+    /"/g,
+    ""
+  );
+  const link =
+    searchParams.linkSearchUrl &&
+    internalLinkRegExp.test(searchParams.linkSearchUrl)
+      ? searchParams.linkSearchUrl.replace(
+          internalLinkRegExp,
+          "https://www.gov.uk/"
+        )
+      : searchParams.linkSearchUrl;
   const queries = [
-    bigQuery(query, { keywords, excludedKeywords, locale, taxon, organisation, link })
+    bigQuery(query, {
+      keywords,
+      excludedKeywords,
+      locale,
+      taxon,
+      organisation,
+      link,
+    }),
   ];
 
   let bqMetaResults: MetaResult[] = [];
@@ -170,74 +211,94 @@ const sendSearchQuery = async function(searchParams: SearchParams): Promise<Sear
     case SearchType.Organisation:
       results = await Promise.all(queries);
       bqMainResults = results[0];
-      bqMetaResults = await getOrganisationInfo(searchParams.selectedOrganisation);
+      bqMetaResults = await getOrganisationInfo(
+        searchParams.selectedOrganisation
+      );
       break;
     default:
-      if (selectedWordsWithoutQuotes &&
+      if (
+        selectedWordsWithoutQuotes &&
         selectedWordsWithoutQuotes.length > 5 &&
-        selectedWordsWithoutQuotes.includes(' ')) {
-        queries.push(bigQuery(
-        `SELECT *
+        selectedWordsWithoutQuotes.includes(" ")
+      ) {
+        queries.push(
+          bigQuery(
+            `SELECT *
          FROM search.thing
          WHERE CONTAINS_SUBSTR(name, @selected_words_without_quotes)
-         ;`
-        , { selectedWordsWithoutQuotes }))
+         ;`,
+            { selectedWordsWithoutQuotes }
+          )
+        );
       }
       results = await Promise.all(queries);
-      bqMainResults = results[0]
+      bqMainResults = results[0];
       bqMetaResults = results.length > 1 ? results[1] : [];
       break;
   }
-  const result:SearchResults = {
+  const result: SearchResults = {
     main: bqMainResults,
-    meta: bqMetaResults
-  }
+    meta: bqMetaResults,
+  };
   return result;
 };
 
-
-const buildSqlQuery = function(searchParams: SearchParams, keywords: string[], excludedKeywords: string[]): string {
-
+const buildSqlQuery = function (
+  searchParams: SearchParams,
+  keywords: string[],
+  excludedKeywords: string[]
+): string {
   const contentToSearch = [];
   if (searchParams.whereToSearch.title) {
     contentToSearch.push('IFNULL(page.title, "")');
   }
   if (searchParams.whereToSearch.text) {
-    contentToSearch.push('IFNULL(page.text, "")', 'IFNULL(page.description, "")');
+    contentToSearch.push(
+      'IFNULL(page.text, "")',
+      'IFNULL(page.description, "")'
+    );
   }
   const contentToSearchString = contentToSearch.join(' || " " || ');
 
-  const includeClause = keywords.length === 0
-    ? ''
-    : 'AND (' + ([...Array(keywords.length).keys()]
-      .map(index => searchParams.caseSensitive
-        ? `STRPOS(${contentToSearchString}, @keyword${index}) <> 0`
-        : `CONTAINS_SUBSTR(${contentToSearchString}, @keyword${index})`)
-      .join(searchParams.combinator === Combinator.Any ? ' OR ' : ' AND ')) + ')';
+  const includeClause =
+    keywords.length === 0
+      ? ""
+      : "AND (" +
+        [...Array(keywords.length).keys()]
+          .map((index) =>
+            searchParams.caseSensitive
+              ? `STRPOS(${contentToSearchString}, @keyword${index}) <> 0`
+              : `CONTAINS_SUBSTR(${contentToSearchString}, @keyword${index})`
+          )
+          .join(searchParams.combinator === Combinator.Any ? " OR " : " AND ") +
+        ")";
 
-  const excludeClause = excludedKeywords.length === 0
-    ? ''
-    : 'AND NOT (' + ([...Array(excludedKeywords.length).keys()]
-      .map(index => searchParams.caseSensitive
-        ? `STRPOS(${contentToSearchString}, @excluded_keyword${index}) <> 0`
-        : `CONTAINS_SUBSTR(${contentToSearchString}, @excluded_keyword${index})`)
-      .join(' OR ')) + ')';
-;
-
-  let areaClause = '';
-  if (searchParams.areaToSearch === 'publisher') {
+  const excludeClause =
+    excludedKeywords.length === 0
+      ? ""
+      : "AND NOT (" +
+        [...Array(excludedKeywords.length).keys()]
+          .map((index) =>
+            searchParams.caseSensitive
+              ? `STRPOS(${contentToSearchString}, @excluded_keyword${index}) <> 0`
+              : `CONTAINS_SUBSTR(${contentToSearchString}, @excluded_keyword${index})`
+          )
+          .join(" OR ") +
+        ")";
+  let areaClause = "";
+  if (searchParams.areaToSearch === "publisher") {
     areaClause = 'AND publishing_app = "publisher"';
-  } else if (searchParams.areaToSearch === 'whitehall') {
+  } else if (searchParams.areaToSearch === "whitehall") {
     areaClause = 'AND publishing_app = "whitehall"';
   }
 
-  let localeClause = '';
-  if (searchParams.selectedLocale !== '') {
-    localeClause = `AND locale = @locale`
+  let localeClause = "";
+  if (searchParams.selectedLocale !== "") {
+    localeClause = `AND locale = @locale`;
   }
 
-  let taxonClause = '';
-  if (searchParams.selectedTaxon !== '') {
+  let taxonClause = "";
+  if (searchParams.selectedTaxon !== "") {
     taxonClause = `
       AND EXISTS
         (
@@ -247,8 +308,8 @@ const buildSqlQuery = function(searchParams: SearchParams, keywords: string[], e
     `;
   }
 
-  let organisationClause = '';
-  if (searchParams.selectedOrganisation !== '') {
+  let organisationClause = "";
+  if (searchParams.selectedOrganisation !== "") {
     organisationClause = `
       AND EXISTS
         (
@@ -258,27 +319,16 @@ const buildSqlQuery = function(searchParams: SearchParams, keywords: string[], e
     `;
   }
 
-  let linkClause = '';
-  if (searchParams.linkSearchUrl !== '') {
-    if (internalLinkRegExp.test(searchParams.linkSearchUrl)) {
-      // internal link search: look for exact match
-      linkClause = `
-        AND EXISTS
-          (
-            SELECT 1 FROM UNNEST (hyperlinks) AS link
-            WHERE link = @link
-          )
-      `;
-    } else {
-      // external link search: look for url as substring
-      linkClause = `
-        AND EXISTS
-          (
-            SELECT 1 FROM UNNEST (hyperlinks) AS link
-            WHERE CONTAINS_SUBSTR(link, @link)
-          )
-      `;
-    }
+  let linkClause = "";
+  if (searchParams.linkSearchUrl !== "") {
+    // Link search: look for url as substring
+    linkClause = `
+      AND EXISTS
+        (
+          SELECT 1 FROM UNNEST (hyperlinks) AS link
+          WHERE CONTAINS_SUBSTR(link, @link)
+        )
+    `;
   }
 
   return `
@@ -314,7 +364,6 @@ const buildSqlQuery = function(searchParams: SearchParams, keywords: string[], e
   `;
 };
 
-
 export {
   getBankHolidayInfo,
   getTransactionInfo,
@@ -323,5 +372,5 @@ export {
   getRoleInfo,
   getTaxonInfo,
   sendInitQuery,
-  sendSearchQuery
+  sendSearchQuery,
 };

--- a/bigquery.ts
+++ b/bigquery.ts
@@ -5,8 +5,6 @@ const { BigQuery } = require('@google-cloud/bigquery');
 
 //====== private ======
 
-const internalLinkRegExp = /^((https:\/\/)?((www\.)?gov\.uk))?\//;
-
 
 const bigquery = new BigQuery({
   projectId: process.env.PROJECT_ID
@@ -150,9 +148,7 @@ const sendSearchQuery = async function(searchParams: SearchParams): Promise<Sear
   const taxon = searchParams.selectedTaxon;
   const organisation = searchParams.selectedOrganisation;
   const selectedWordsWithoutQuotes = searchParams.selectedWords.replace(/"/g, '');
-  const link = searchParams.linkSearchUrl && internalLinkRegExp.test(searchParams.linkSearchUrl)
-    ? searchParams.linkSearchUrl.replace(internalLinkRegExp, 'https://www.gov.uk/')
-    : searchParams.linkSearchUrl;
+  const link = searchParams.linkSearchUrl
   const queries = [
     bigQuery(query, { keywords, excludedKeywords, locale, taxon, organisation, link })
   ];

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,5 +8,6 @@ module.exports = {
     "^.+\\.tsx?$": "ts-jest",
   },
   moduleFileExtensions: ["js", "ts", "json", "node"],
-  collectCoverage: true,
+  // Uncomment this if we want to use coverage
+  // collectCoverage: true,
 };

--- a/src/tests/bigquery.test.ts
+++ b/src/tests/bigquery.test.ts
@@ -1,0 +1,59 @@
+import {
+  SearchParams,
+  Combinator,
+  SearchArea,
+  SearchType,
+} from "../ts/search-api-types";
+import { buildSqlQuery } from "../../bigquery";
+
+const makeParams = (opts = {}) =>
+  ({
+    linkSearchUrl: "",
+    whereToSearch: { title: true, text: true },
+    caseSensitive: false,
+    combinator: Combinator.Any,
+    areaToSearch: SearchArea.Any,
+    selectedLocale: "",
+    selectedTaxon: "",
+    selectedOrganisation: "",
+    searchType: SearchType.Advanced,
+    selectedWords: "",
+    excludedWords: "",
+    ...opts,
+  } as SearchParams);
+
+describe("buildSqlQuery", () => {
+  test("includes linkClause when searchParams.linkSearchUrl is not an empty string", () => {
+    const searchParams: SearchParams = makeParams({
+      linkSearchUrl: "test-url",
+    });
+    const keywords: string[] = [];
+    const excludedKeywords: string[] = [];
+
+    const query = buildSqlQuery(searchParams, keywords, excludedKeywords);
+
+    expect(query).toContain(
+      `AND EXISTS
+        (
+          SELECT 1 FROM UNNEST (hyperlinks) AS link
+          WHERE CONTAINS_SUBSTR(link, @link)
+        )`
+    );
+  });
+
+  test("doesn't include linkClause when searchParams.linkSearchUrl is an empty string", () => {
+    const searchParams: SearchParams = makeParams();
+    const keywords: string[] = [];
+    const excludedKeywords: string[] = [];
+
+    const query = buildSqlQuery(searchParams, keywords, excludedKeywords);
+
+    expect(query).not.toContain(
+      `AND EXISTS
+        (
+          SELECT 1 FROM UNNEST (hyperlinks) AS link
+          WHERE CONTAINS_SUBSTR(link, @link)
+        )`
+    );
+  });
+});


### PR DESCRIPTION
# Problem
Users searching for URL keyword substrings with a trailing slash, intending to match all associated links, received only exact matches in the search results.

# Origin of the Problem
The backend system differentiated link searches based on the domain of the link. For same domain links (those with a trailing slash, or starting with [www.gov.uk/](http://www.gov.uk/) or https://www.gov.uk/), an exact match search was performed. For external links, a partial match search was done using the substring.

# Solution
Updated the backend to do substring searches for all search link requests, without distinguishing between same domain links and external ones.

# How to test
## Unit Tests
Run the unit tests with `npm run test`

## Manual Test
Go to GovSearch staging
Go to the advance tab
Paste this into the "Search for links" text box: `/email-signup?link=/topic/`
Submit the search
AC 1: you should get results
AC 2: for each result item, the page it points to contains at least on link containing the substring you've searched for





# Before: 
![image](https://github.com/alphagov/govuk-knowledge-graph-search/assets/22219650/875a796b-7f15-489e-a67d-975118bf484c)


# After:
![Screenshot 2023-06-06 at 14 49 45](https://github.com/alphagov/govuk-knowledge-graph-search/assets/22219650/3e6c6534-eedf-4833-bfc8-a0b390e1041c)

