### PR TITLE
Banner in integration env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN sass src/scss/main.scss > public/main.css
 # Compile TypeScript to JavaScript (browser)
 RUN npx webpack
 
-CMD npm start
+CMD ["npm", "start"]

--- a/app.ts
+++ b/app.ts
@@ -1,3 +1,6 @@
+import fs from 'fs'
+import path from 'path'
+
 import express from 'express'
 import { auth } from './src/ts/middlewares'
 
@@ -105,9 +108,16 @@ if (process.env.ENABLE_AUTH === 'true') {
   )
 }
 
-app.get('/', auth(), async (req, res) =>
-  res.sendFile('views/index.html', { root: __dirname })
-)
+app.get('/', auth(), async (req, res) => {
+  const fileName = path.join(__dirname, 'views', 'index.html')
+  const content = fs.readFileSync(fileName, 'utf-8')
+  const processedContent = content.replace(
+    '__NODE_ENV__',
+    process.env.NODE_ENV || ''
+  )
+
+  res.send(processedContent)
+})
 
 // the front-end will call this upon starting to get some data needed from the server
 app.get('/get-init-data', auth('/'), async (req, res) => {

--- a/src/ts/constants.ts
+++ b/src/ts/constants.ts
@@ -1,0 +1,6 @@
+export enum ENV {
+  // Values should reflect the terraform variables
+  DEVELOPMENT = 'development',
+  STAGING = 'staging',
+  PRODUCTION = 'production',
+}

--- a/src/ts/view/view.ts
+++ b/src/ts/view/view.ts
@@ -5,6 +5,7 @@ import { languageName } from '../lang'
 import { viewMetaResults } from './view-metabox'
 import { viewSearchPanel } from './view-search-panel'
 import { EventType } from '../event-types'
+import { ENV } from '../constants'
 
 declare const window: any
 
@@ -15,6 +16,7 @@ const view = () => {
   if (pageContent) {
     pageContent.innerHTML = `
       <main class="govuk-main-wrapper" id="main-content" role="main">
+        ${viewContextBanner()}
         ${viewErrorBanner()}
         ${viewSearchTypeSelector()}
         ${viewMainLayout()}
@@ -119,6 +121,25 @@ const viewMainLayout = () => {
     `)
   }
   return result.join('')
+}
+
+const viewContextBanner = () => {
+  const isIntegrationEnv = window.NODE_ENV === ENV.DEVELOPMENT
+  if (isIntegrationEnv) {
+    return ` 
+    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                Important
+            </h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+            <p class="govuk-notification-banner__heading">This is the integration environment and may not be stable please use the <a class="govuk-notification-banner__link" href="https://gov-search.service.gov.uk/">live application</a>.</p>
+        </div>
+    </div>
+    `
+  }
+  return ''
 }
 
 const viewErrorBanner = () => {

--- a/views/index.html
+++ b/views/index.html
@@ -66,6 +66,10 @@
     <!-- INSERT GTM BODY SNIPPET -->
 
     <script>
+      window.NODE_ENV = '__NODE_ENV__' // optionally overriden at build time
+    </script>
+
+    <script>
       document.body.className = document.body.className
         ? document.body.className + ' js-enabled'
         : 'js-enabled'


### PR DESCRIPTION
This PR introduces support for server variables to be passed to the frontend to display a banner in the integration environment.

The implementation involves modifying the index.html file using templating, where the server dynamically provides the environment variable value.

The environment variable is assigned to the window.NODE_ENV object through string replacement in the endpoint.

This PR is dependent on [this change](https://github.com/alphagov/govuk-knowledge-graph-gcp/pull/505) to make the environment variable available in Terraform.


![image](https://github.com/alphagov/govuk-knowledge-graph-search/assets/22219650/97146b72-85f8-4f9c-986f-b26e2e0adadd)


![image](https://github.com/alphagov/govuk-knowledge-graph-search/assets/22219650/df5bb125-e8b6-41d2-b94f-c71e933bceaa)


# How to test

Deploy the change in dev and test the banner is displaying. There is an existing revision with commit tag `b8232e`.
Equally, test the banned isn't displayed when deployed in other environments.

