### PR TITLE
Handle orgs that have multiple parents in infobox

### DIFF
--- a/src/common/types/search-api-types.ts
+++ b/src/common/types/search-api-types.ts
@@ -69,7 +69,7 @@ export type Organisation = {
   name: string
   homepage: string
   description: string
-  parentName: string
+  parentOrgNames: string[]
   childOrgNames: string[]
   personRoleNames: {
     personName: string

--- a/src/frontend/view/view-metabox.ts
+++ b/src/frontend/view/view-metabox.ts
@@ -39,6 +39,13 @@ const viewOrgPersonRoles = (personRoles: Record<string, any>[]): string =>
       )})`
   )
 
+const viewOrgParents = (parentOrgNames: string[]): string =>
+  viewDetails(
+    `${parentOrgNames.length} parent organisations`,
+    parentOrgNames.sort(),
+    viewMetaLink
+  )
+
 const viewOrgChildren = (childOrgNames: string[]): string =>
   viewDetails(
     `${childOrgNames.length} sub-organisations`,
@@ -211,10 +218,13 @@ const viewOrg = (record: Organisation): string => `
       <a class="govuk-link" href="${record.homepage}">${record.name}</a>
     </h2>
     <p class="govuk-body">
-      Government organisation${
-        record.parentName ? `, part of ${viewMetaLink(record.parentName)}` : ''
-      }
+      Government organisation
     </p>
+    ${
+      record.parentOrgNames && record.parentOrgNames.length > 0
+        ? viewOrgParents(record.parentOrgNames)
+        : ''
+    }
     ${
       record.supersededBy.length > 0
         ? `


### PR DESCRIPTION
Trello: https://trello.com/c/A1Ywzb4S/2279-make-searchorganisation-distinct-on-name

Mutually dependent on https://github.com/alphagov/govuk-knowledge-graph-gcp/pull/526

Some organisations have more than one parent organisation.  For example,
the Animal and Plant Health Agency.  The infobox would never display
for such an organisation.

Why the infobox wouldn't display:

Because the organisation would have multiple matching rows
in the `thing` table (one per parent organisation), and we assumed that
if the `thing` query returned more than one row, then there was more
than one thing.  Since we can only display one infobox, we could either
arbitrarily choose one of the 'things' to display, or not display the
infobox at all.  We chose not to display it at all.

What this commit changes

We now assume that an organisation might have zero, 1 or many parent
organisations, named in an array, and display them similarly to any
child organisations.
