### PR TITLE
Add CD pipeline to the main branch

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,53 @@
+name: Deploy to Cloud Run
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: staging
+
+    steps:
+      - name: Print environment variable
+        run: echo "Value of GCP_PROJECT_ID is ${{ vars.GCP_PROJECT_ID }}"
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0.2.1
+        with:
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Project
+        run: npm run clean-build
+
+      - name: Generate Tag
+        id: generate_tag
+        run: |
+          echo "TAG=cd-commit-$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+
+      - name: Deploy to Cloud Run
+        id: deploy
+        run: |
+          gcloud run deploy govuk-knowledge-graph-search \
+            --source . \
+            --region "europe-west2" \
+            --tag ${{ env.TAG }} \
+            --no-traffic \
+            --project ${{ vars.GCP_PROJECT_ID }}
+
+      - name: Route Traffic to New Revision
+        run: |
+          gcloud run services update-traffic govuk-knowledge-graph-search \
+            --to-tags ${{ env.TAG }}=100 \
+            --region "europe-west2" \
+            --project ${{ vars.GCP_PROJECT_ID }}


### PR DESCRIPTION
This PR adds a CD pipeline to the main branch.

The following Github repository settings were also put in place:
- Only selected developers can approve a PR (all the dev team)
- `main` cannot be pushed / force-pushed to, it has to be a PR
- Automatically merge the PR if it has been approved and CI has passed.
- A Github "staging" environment was created. It provides the actions with secrets and environment variables, such as the Google Service Account secret that's necessary for authenticating the deploy github action.


The Pipeline does the following:
1. Clone & setup & build the project
2. Create a specific tag. CD deploys will be recognisable with the `cd-` suffix to the tag.
3. Deploy the build
4. Route all the traffic to the latest revision. That way, we don't have to do anything manual other than merging the PR.


The service account for now was created manually in the GCP console. We can't terraform, a new secret key would have to be generated and added to the github environment each time we recreate the service account. Automating that secret rotation is tricky.

Instead, we might move to [Workload Identity Federation for GitHub](https://cloud.google.com/blog/products/identity-security/enabling-keyless-authentication-from-github-actions) later on, which will solve this issue.


Here are the roles I've given the service account, and thus the Github Action:
- roles/run.admin
- roles/iam.serviceAccountUser
- roles/cloudbuild.builds.editor
- roles/storage.objectAdmin
- roles/artifactregistry.admin
- roles/cloudbuild.builds.builder