### PR TITLE
[DO NOT MERGE YET] Update SQL to accommodate link types

### DIFF
--- a/src/backend/bigquery/buildSqlQuery.test.ts
+++ b/src/backend/bigquery/buildSqlQuery.test.ts
@@ -206,7 +206,7 @@ describe('buildSqlQuery', () => {
     AND EXISTS
     (
       SELECT 1 FROM UNNEST (hyperlinks) AS link
-      WHERE CONTAINS_SUBSTR(link, @link)
+      WHERE CONTAINS_SUBSTR(link.link_url, @link)
     )
     `
     const expected = expectedQuery(expectedClauses)
@@ -246,7 +246,7 @@ describe('buildSqlQuery', () => {
   AND EXISTS
     (
       SELECT 1 FROM UNNEST (hyperlinks) AS link
-      WHERE CONTAINS_SUBSTR(link, @link)
+      WHERE CONTAINS_SUBSTR(link.link_url, @link)
     )
   `
     const expected = expectedQuery(expectedClauses)

--- a/src/backend/bigquery/buildSqlQuery.ts
+++ b/src/backend/bigquery/buildSqlQuery.ts
@@ -83,7 +83,7 @@ export const buildSqlQuery = function (
       AND EXISTS
         (
           SELECT 1 FROM UNNEST (hyperlinks) AS link
-          WHERE CONTAINS_SUBSTR(link, @link)
+          WHERE CONTAINS_SUBSTR(link.link_url, @link)
         )
     `
   }


### PR DESCRIPTION
A [change](https://github.com/alphagov/govuk-knowledge-graph-gcp/pull/533) to the GCP backend (BigQuery) is proposed to make link types available alongside link URLS in the `search.page` table.

It is necessary to update some SQL in the front-end to ensure that pages are returned only when search terms are present within the link URLs (`link_url`), and **not** within the link type (`link_type`).

Specifically, this change introduces an additional dot notation to:

 - Perform string matching against newly-proposed `link_url` field (**only**) in the nested `hyperlinks` column
 - Omit `link_type` from string matching

More information can be found in [this comment](https://github.com/alphagov/govuk-knowledge-graph-gcp/pull/533#issuecomment-1651750496) against the PR in the GCP repository.