### PR TITLE
Sanitise SQL of occurrences

### DIFF
--- a/src/backend/utils/csv.ts
+++ b/src/backend/utils/csv.ts
@@ -59,6 +59,7 @@ const csvFieldFormatters: Record<string, any> = {
     name: 'Withdrawn reason',
     format: (text: string) => text || 'No data available',
   },
+  occurrences: { name: 'Occurrences' },
 }
 
 // generate a human-readable string depending on the type of field

--- a/src/common/types/search-api-types.ts
+++ b/src/common/types/search-api-types.ts
@@ -174,3 +174,8 @@ export type InitResults = {
   organisations: string[]
   documentTypes: string[]
 }
+
+export type Occurrence = {
+  keyword: string[]
+  occurrences: number[]
+}

--- a/src/frontend/view/utils.ts
+++ b/src/frontend/view/utils.ts
@@ -1,6 +1,6 @@
 import { languageName } from '../../common/utils/lang'
-import { state } from '../state'
 import { Field } from '../types/state-types'
+import { Occurrence } from '../../common/types/search-api-types'
 
 export const formatNames = (array: []) =>
   [...new Set(array)].map((x) => `“${x}”`).join(', ')
@@ -10,33 +10,18 @@ export const formatDateTime = (date: any) =>
     ? `${date.value.slice(0, 10)} at ${date.value.slice(11, 16)}`
     : 'No data available'
 
-const splitKeywords = function (keywords: string): string[] {
-  const wordsToIgnore = ['of', 'for', 'the', 'or', 'and']
-  const regexp = /[^\s,"]+|"([^"]*)"/gi
-  const output = []
-  let match: RegExpExecArray | null
-  do {
-    match = regexp.exec(keywords)
-    if (match) {
-      output.push(match[1] ? match[1] : match[0])
-    }
-  } while (match)
-  return output.filter((d) => d.length > 0 && !wordsToIgnore.includes(d))
-}
-
-const formatOccurrences = (obj: any) =>
-  obj && Object.values(obj)?.length > 1
-    ? `Total (${Object.values(obj).reduce(
-        (partialSum: any, a: any) => partialSum + a,
+export const formatOccurrences = (occurrences: [Occurrence]) =>
+  occurrences.length > 1
+    ? `Total (${occurrences.reduce(
+        (partialSum: any, occurrence: Occurrence) =>
+          partialSum + occurrence.occurrences,
         0
-      )}),
-      ${Object.values(obj)
+      )}), ${occurrences
         .map(
-          (x, i) =>
-            `${splitKeywords(state.searchParams.selectedWords)[i]} (${x})`
+          (occurrence) => `${occurrence.keyword} (${occurrence.occurrences})`
         )
         .join(', ')}`
-    : `${obj}`
+    : `${occurrences[0].occurrences}`
 
 export const fieldFormatters: Record<Field, any> = {
   url: {


### PR DESCRIPTION
- Use SQL parameters instead of interpolated strings, which are insecure
- No need to escape special characters, which is tricky to do without
  affecting the search results, e.g. http://localhost:8080/?selected-words=%22new+style%27
- Support case sensitivity
- Handle the case of zero keywords (which aren't yet supported in the
  front end, but are supported in other parts of the code)
- Sum the counts of occurrences of each term by using SQL, rather than
  frontend typescript. This also means that `splitKeywords()` for remove
  stopwords doesn't have to be reimplemented in the frontend.

Only the case-sensitive version is tested.  The tests ought to be
overhauled anyway.  They test the logic that constructs SQL
queries, and in order to create test cases, they implement ... logic that
constructs SQL queries.  It would be better to somehow execute the
queries against a static test dataset, which would require a new Google
Cloud project with a BigQuery dataset that has the same name as these
queries refer to.

Cypress tests are currently nearly all broken, so this PR doesn't introduce any.  For now, the display of occurrences should be `10` if the keyword is `hello` with 10 occurrences, otherwise `Total (11), hello (10), world(1)` if the keywords are `hello world` with 10 and 1 occurrences respectively.