### PR TITLE
Searches do include history mode content

### DIFF
--- a/src/frontend/view/view.ts
+++ b/src/frontend/view/view.ts
@@ -38,7 +38,7 @@ const view = () => {
           ${viewMainLayout()}
         </div>
         <div class="govuk-inset-text">
-          Searches do not include history mode content, GitHub smart answers or service domains.
+          Searches do not include GitHub smart answers or service domains.
           Page views depend on cookie consent. Data can be up to 24 hours delayed.
         </div>
       </div>`)


### PR DESCRIPTION
This edits the caveat to omit the claim that search results exclude
history mode content.

An example of a page that is in history mode is https://www.gov.uk/government/publications/the-government-s-response-to-sir-michael-pitt-s-review-of-the-summer-2007-floods--2

That page is include in the results of this search https://gov-search.service.gov.uk/?selected-words=The+government%E2%80%99s+response+to+Sir+Michael+Pitt%E2%80%99s+review+of+the+summer+2007+floods%3A+progress+report+2009&keyword-location=title

> Content is considered to be "in history mode" if it is flagged as being political and it is associated with a government that is not the current government.

https://docs.publishing.service.gov.uk/repos/content-publisher/history-mode.html#when-is-content-in-history-mode

See also https://github.com/alphagov/govuk-knowledge-graph-gcp/issues/554
