### PR TITLE
feat: allow empty keyword search

### DIFF
--- a/src/common/utils/utils.test.ts
+++ b/src/common/utils/utils.test.ts
@@ -8,6 +8,13 @@ describe('[Function] splitKeywords', () => {
     const result = splitKeywords(searchString)
     expect(result).toEqual(expected)
   })
+  it('should handle the empty string', () => {
+    const searchString: string = ''
+    const expected: string[] = []
+
+    const result = splitKeywords(searchString)
+    expect(result).toEqual(expected)
+  })
   it('should handle quoted strings', () => {
     const searchString = '"test1 test2" test3'
     const expected = ['test1 test2', 'test3']

--- a/src/common/utils/utils.test.ts
+++ b/src/common/utils/utils.test.ts
@@ -9,7 +9,7 @@ describe('[Function] splitKeywords', () => {
     expect(result).toEqual(expected)
   })
   it('should handle the empty string', () => {
-    const searchString: string = ''
+    const searchString = ''
     const expected: string[] = []
 
     const result = splitKeywords(searchString)

--- a/src/frontend/events.ts
+++ b/src/frontend/events.ts
@@ -287,21 +287,8 @@ const searchButtonClicked = async function (): Promise<void> {
   const searchStatus = searchState()
   switch (searchStatus.code) {
     case 'ready-to-search':
-      if (
-        state.searchParams.selectedWords !== '' ||
-        (state.searchParams.language !== '' &&
-          state.searchParams.language !== defaultAllLanguagesOption) ||
-        state.searchParams.taxon !== '' ||
-        state.searchParams.publishingOrganisation !== '' ||
-        state.searchParams.linkSearchUrl !== '' ||
-        state.searchParams.documentType !== '' ||
-        state.searchParams.publishingApplication !==
-          PublishingApplication.Any ||
-        state.searchParams.publishingStatus !== PublishingStatus.All
-      ) {
-        state.waiting = true
-        queryBackend(state.searchParams, handleEvent)
-      }
+      state.waiting = true
+      queryBackend(state.searchParams, handleEvent)
       break
     case 'error':
       state.userErrors = searchStatus.errors

--- a/src/frontend/state.ts
+++ b/src/frontend/state.ts
@@ -181,10 +181,14 @@ const searchState = function (): { code: string; errors: string[] } {
   if (
     state.searchParams.selectedWords === '' &&
     state.searchParams.excludedWords === '' &&
+    (state.searchParams.language === '' ||
+      state.searchParams.language === defaultAllLanguagesOption) &&
     state.searchParams.taxon === '' &&
     state.searchParams.publishingOrganisation === '' &&
-    state.searchParams.language === '' &&
-    state.searchParams.linkSearchUrl === ''
+    state.searchParams.linkSearchUrl === '' &&
+    state.searchParams.documentType === '' &&
+    state.searchParams.publishingApplication === PublishingApplication.Any &&
+    state.searchParams.publishingStatus === PublishingStatus.All
   ) {
     return { code: 'initial', errors }
   }

--- a/src/frontend/state.ts
+++ b/src/frontend/state.ts
@@ -165,6 +165,21 @@ const setStateSearchParamsFromURL = function (): void {
   )
 }
 
+const searchStateIsUnset = function (): boolean {
+  return (
+    state.searchParams.selectedWords === '' &&
+    state.searchParams.excludedWords === '' &&
+    (state.searchParams.language === '' ||
+      state.searchParams.language === defaultAllLanguagesOption) &&
+    state.searchParams.taxon === '' &&
+    state.searchParams.publishingOrganisation === '' &&
+    state.searchParams.linkSearchUrl === '' &&
+    state.searchParams.documentType === '' &&
+    state.searchParams.publishingApplication === PublishingApplication.Any &&
+    state.searchParams.publishingStatus === PublishingStatus.All
+  )
+}
+
 const searchState = function (): { code: string; errors: string[] } {
   // Find out what to display depending on state
   // returns an object with a "code" field
@@ -178,18 +193,7 @@ const searchState = function (): { code: string; errors: string[] } {
 
   if (state.waiting) return { code: 'waiting', errors }
 
-  if (
-    state.searchParams.selectedWords === '' &&
-    state.searchParams.excludedWords === '' &&
-    (state.searchParams.language === '' ||
-      state.searchParams.language === defaultAllLanguagesOption) &&
-    state.searchParams.taxon === '' &&
-    state.searchParams.publishingOrganisation === '' &&
-    state.searchParams.linkSearchUrl === '' &&
-    state.searchParams.documentType === '' &&
-    state.searchParams.publishingApplication === PublishingApplication.Any &&
-    state.searchParams.publishingStatus === PublishingStatus.All
-  ) {
+  if (searchStateIsUnset()) {
     return { code: 'initial', errors }
   }
 


### PR DESCRIPTION
- chore: add test for no keywords
  
  This will eventually support searches that use filters without keywords,  such as to find all pages published by a certain organisation.
- feat: allow empty keyword search when filters given
  
  If we were to allow empty keyword search without any filters, then the  homepage would immediately run a search, returning 10k results from the  entire content of GOV.UK.  So we require at least one filter.
  
  For non-keyword searches, we don't require any filters, but we do  still require a thing (link, organisation, etc.) to search for.
  
  This commit removes the redundant checks in the searchButtonClicked  function, in favour of the ones in the searchState function.  It adds  checks of documentType, publishingStatus and publishingApplication.
