### PR TITLE
fix: custom events should be sent to GA not window object

### DIFF
--- a/src/frontend/view/utils.ts
+++ b/src/frontend/view/utils.ts
@@ -100,14 +100,11 @@ export const fieldFormat = function (
 }
 
 export const dispatchCustomGAEvent = (name: string, detail: any = {}) => {
-  const prefix = 'custom-'
-  const eventName = `${prefix}${name}`
-
   // @ts-ignore
   if (window.dataLayer) {
     // @ts-ignore
     window.dataLayer.push({
-      event: eventName,
+      event: name,
       ...detail,
     })
   }

--- a/src/frontend/view/view.ts
+++ b/src/frontend/view/view.ts
@@ -74,8 +74,7 @@ const view = () => {
     event.preventDefault()
     // Tell GTM the form was submitted
     window.dataLayer = window.dataLayer || []
-    window.dataLayer.push({
-      event: 'formSubmission',
+    dispatchCustomGAEvent('formSubmission', {
       formType: 'Search',
       formPosition: 'Page',
     })


### PR DESCRIPTION
For Esmee to access the events, they need to be sent to the GTM via the dataLayer.

Previously, this function was just throwing simple JS events.