### PR TITLE
Update the query description on change of sort

### DIFF
--- a/src/frontend/types/state-types.ts
+++ b/src/frontend/types/state-types.ts
@@ -23,6 +23,10 @@ export enum SortAction {
   NONE = '',
 }
 
+export type Sorting = Partial<
+  Record<Field, { sortIndex: number; sort: SortAction }>
+>
+
 export interface State {
   searchParams: SearchParams
   taxons: string[]

--- a/src/frontend/utils/queryDescription.test.ts
+++ b/src/frontend/utils/queryDescription.test.ts
@@ -1,4 +1,5 @@
-import { queryDescription } from './queryDescription'
+import { queryDescription, sortDescription } from './queryDescription'
+import { Sorting, SortAction } from '../types/state-types'
 import {
   Combinator,
   KeywordLocation,
@@ -175,7 +176,7 @@ describe('queryDescription', () => {
     }
     const description = queryDescription(params)
     expect(description).toContain(
-      'Searching for pages that  contain <span class="govuk-!-font-weight-bold">test</span>'
+      'Searching for pages that contain <span class="govuk-!-font-weight-bold">test</span>'
     )
   })
 
@@ -189,7 +190,15 @@ describe('queryDescription', () => {
     }
     const description = queryDescription(params)
     expect(description).toContain(
-      '<span class="govuk-!-font-weight-bold">5 results</span> for pages that  contain <span class="govuk-!-font-weight-bold">test</span>'
+      '<span class="govuk-!-font-weight-bold">5 results</span> for pages that contain <span class="govuk-!-font-weight-bold">test</span>'
     )
+  })
+
+  it('should describe the sort order', () => {
+    const sorting: Sorting = {
+      page_views: { sortIndex: 0, sort: SortAction.DESC },
+    }
+    const description = sortDescription(sorting)
+    expect(description).toContain(', sorted by "Views (7days)" (descending)')
   })
 })

--- a/src/frontend/utils/queryDescription.ts
+++ b/src/frontend/utils/queryDescription.ts
@@ -1,3 +1,5 @@
+import { Sorting } from '../types/state-types'
+import { fieldName, sortOrder } from '../view/utils'
 import {
   KeywordLocation,
   PublishingApplication,
@@ -75,8 +77,6 @@ export const queryDescription = ({
       )}`
     )
 
-  clauses.push(`are sorted by ${makeBold('page views', includeMarkup)} (desc)`)
-
   const joinedClauses =
     clauses.length === 1
       ? clauses[0]
@@ -84,12 +84,16 @@ export const queryDescription = ({
           clauses[clauses.length - 1]
         }`
 
+  // The sort order description gets written directly into the DOM by the AgGrid
+  // onSortChanged event handler.
+  const sortOrderClause = '<span id="sort-description"/>'
+
   const prefix = waiting
     ? 'Searching for'
     : nbRecords
     ? `${makeBold(`${nbRecords} result${nbRecords > 1 ? 's' : ''}`, true)} for`
     : ''
-  return `${prefix} pages that ${joinedClauses}`
+  return `${prefix} pages that ${joinedClauses.trim()}${sortOrderClause}.`
 }
 
 // combinedWords as used here must be exactly the same set of keywords as the ones submitted to BigQuery by the function sendSearchQuery.
@@ -107,4 +111,29 @@ const containDescription = (search: SearchParams, includeMarkup: boolean) => {
     .map((w) => makeBold(w, includeMarkup))
     .join(` ${combineOp} `)
   return search.selectedWords !== '' ? `${combinedWords} ${where}` : ''
+}
+
+export const sortDescription = (sorting: Sorting) => {
+  const isSorted = Object.keys(sorting).length !== 0
+  if (!isSorted) {
+    return ''
+  }
+  const numberOfSortedColumns = Object.entries(sorting).length
+  const description = Object.entries(sorting)
+    // Rearrange into something that can be ordered by sortIndex
+    .map(([k, v]) => ({
+      name: k,
+      // The final column has a null sortIndex at this point, for some reason
+      index: v.sortIndex != null ? v.sortIndex + 1 : numberOfSortedColumns,
+      order: v.sort,
+    }))
+    // Reorder by sortIndex
+    .sort(function (a, b) {
+      if (a.index + 0 === b.index + 0) return 0
+      return a.index + 0 > b.index + 0 ? 1 : -1
+    })
+    // Compose the description
+    .map((field) => `"${fieldName(field.name)}" (${sortOrder(field.order)})`)
+    .join(`, then by `)
+  return `, sorted by ${description}`
 }

--- a/src/frontend/view/customAgGridHeader.ts
+++ b/src/frontend/view/customAgGridHeader.ts
@@ -1,5 +1,6 @@
 import { state } from '../state'
 import { SortAction } from '../types/state-types'
+import { sortDescription } from '../utils/queryDescription'
 
 interface AgParams {
   menuIcon: string
@@ -108,7 +109,11 @@ export default class CustomAgGridHeader {
     }
     this.updateState()
     this.updateSortingClass()
-    // this.updateText()
+
+    // Ideally we'd update the query description via handleEvent(), but doing so
+    // creates an infinite loop. Instead, we update the element directly.
+    const description = document.getElementById('sort-description')
+    description.textContent = sortDescription(this.sortModel)
   }
 
   private get headerHtmlContent() {

--- a/src/frontend/view/utils.ts
+++ b/src/frontend/view/utils.ts
@@ -87,7 +87,7 @@ export const fieldFormatters: Record<Field, any> = {
 }
 
 export const fieldName = function (key: string) {
-  const f = fieldFormatters[key]
+  const f = fieldFormatters[<Field>key]
   return f ? f.name : key
 }
 
@@ -95,7 +95,7 @@ export const fieldFormat = function (
   key: string,
   val: string | number
 ): string {
-  const f = fieldFormatters[key]
+  const f = fieldFormatters[<Field>key]
   return f && f.format ? f.format(val) : val
 }
 

--- a/src/frontend/view/utils.ts
+++ b/src/frontend/view/utils.ts
@@ -109,3 +109,16 @@ export const dispatchCustomGAEvent = (name: string, detail: any = {}) => {
     })
   }
 }
+
+export const sortOrder = function (key: string) {
+  const sortOrderFormatters: Record<string, any> = {
+    asc: {
+      name: 'ascending',
+    },
+    desc: {
+      name: 'descending',
+    },
+  }
+  const s = sortOrderFormatters[key]
+  return s ? s.name : key
+}


### PR DESCRIPTION
[Trello](https://trello.com/c/nYhWh76a/105-bug-search-description-should-reflect-sorting)

The query description includes how the results are sorted, by what columns, whether ascending or descending, and in what priority. Previously it was hardcoded to the order in which the API returns the records. Since the user can now change the displayed sort order, the query description must be discarded (worse for accessibility) or made dynamic.

We chose to do this by breaking the "Elm architecture" (described in the readme), so that instead of handling the table's sortChanged event with handleEvent(), like other events, we directly update a placeholder <span>.  This avoids an infinite loop, caused by handleEvent() eventually triggering another sortChanged event. The alternative seemed to require a lot of refactoring, which isn't justified by this small enhancement.

Details:

* Refactor the building of the sort description string into its own function, which receives the sort state directly from the event  listener.
* Don't include the sort order in the query description until the results are displayed, and only when they are sorted.
* Add a formatter for "desc" and "asc"