### PR TITLE
Send user's organisation to analytics

### DIFF
--- a/src/backend/constants/routes.ts
+++ b/src/backend/constants/routes.ts
@@ -6,7 +6,7 @@ interface Routes {
 }
 
 export enum Route {
-  signon = '/signon',
+  me = '/me',
   search = '/',
   getInitData = '/get-init-data',
   searchApi = '/search',

--- a/src/backend/constants/routes.ts
+++ b/src/backend/constants/routes.ts
@@ -6,6 +6,7 @@ interface Routes {
 }
 
 export enum Route {
+  signon = '/signon',
   search = '/',
   getInitData = '/get-init-data',
   searchApi = '/search',

--- a/src/backend/constants/types.ts
+++ b/src/backend/constants/types.ts
@@ -6,5 +6,9 @@ export type SignonProfileData = {
     permissions: {
       [key: string]: string[]
     }
+    remotely_signed_out: boolean
+    organisation_slug: string
+    disable: boolean
+    organisation_content_id: string
   }
 }

--- a/src/backend/constants/types.ts
+++ b/src/backend/constants/types.ts
@@ -12,3 +12,9 @@ export type SignonProfileData = {
     organisation_content_id: string
   }
 }
+
+export type SignonProfile = {
+  accessToken: string
+  profileData: SignonProfileData
+  refreshToken: string
+}

--- a/src/backend/controllers/me.controller.ts
+++ b/src/backend/controllers/me.controller.ts
@@ -1,8 +1,8 @@
 import { RequestHandler } from 'express'
 import { SignonProfile } from '../constants/types'
 
-class SignonController {
-  public signon: RequestHandler = (req, res, next) => {
+class MeController {
+  public me: RequestHandler = (req, res, next) => {
     if (req?.user) {
       const profile = req?.user as SignonProfile
       return res.json(profile.profileData || {})
@@ -11,4 +11,4 @@ class SignonController {
   }
 }
 
-export default SignonController
+export default MeController

--- a/src/backend/controllers/signon.controller.ts
+++ b/src/backend/controllers/signon.controller.ts
@@ -1,0 +1,14 @@
+import { RequestHandler } from 'express'
+import { SignonProfile } from '../constants/types'
+
+class SignonController {
+  public signon: RequestHandler = (req, res, next) => {
+    if (req?.user) {
+      const profile = req?.user as SignonProfile
+      return res.json(profile.profileData || {})
+    }
+    next()
+  }
+}
+
+export default SignonController

--- a/src/backend/routes/IndexRoutes.ts
+++ b/src/backend/routes/IndexRoutes.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express'
-import SignonController from '../controllers/signon.controller'
+import MeController from '../controllers/me.controller'
 import SearchController from '../controllers/search.controller'
 import SearchAPIController from '../controllers/searchAPI.controller'
 import InfoBoxController from '../controllers/infoBox.controller'
@@ -11,7 +11,7 @@ import { auth } from '../middleware/auth'
 
 class IndexRoute implements Routes {
   public router = Router()
-  public signonController = new SignonController()
+  public meController = new MeController()
   public searchController = new SearchController()
   public searchAPIController = new SearchAPIController()
   public infoBoxController = new InfoBoxController()
@@ -24,7 +24,7 @@ class IndexRoute implements Routes {
   }
 
   private initializeRoutes() {
-    this.router.get(Route.signon, auth(), this.signonController.signon)
+    this.router.get(Route.me, auth(), this.meController.me)
 
     this.router.get(Route.search, auth(), this.searchController.search)
 

--- a/src/backend/routes/IndexRoutes.ts
+++ b/src/backend/routes/IndexRoutes.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express'
+import SignonController from '../controllers/signon.controller'
 import SearchController from '../controllers/search.controller'
 import SearchAPIController from '../controllers/searchAPI.controller'
 import InfoBoxController from '../controllers/infoBox.controller'
@@ -10,6 +11,7 @@ import { auth } from '../middleware/auth'
 
 class IndexRoute implements Routes {
   public router = Router()
+  public signonController = new SignonController()
   public searchController = new SearchController()
   public searchAPIController = new SearchAPIController()
   public infoBoxController = new InfoBoxController()
@@ -22,6 +24,8 @@ class IndexRoute implements Routes {
   }
 
   private initializeRoutes() {
+    this.router.get(Route.signon, auth(), this.signonController.signon)
+
     this.router.get(Route.search, auth(), this.searchController.search)
 
     this.router.get(

--- a/src/frontend/events.ts
+++ b/src/frontend/events.ts
@@ -203,6 +203,7 @@ const handleEvent: SearchApiCallback = async function (event) {
             event: 'formSubmission',
             formType: 'Search',
             formPosition: 'Page',
+            userOrganisation: state.signonProfileData.user.organisation_slug,
           })
 
           updateStateFromSearchFilters()

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -21,7 +21,7 @@ import {
 // dummy comment
 
 const signon = async function () {
-  state.signonProfileData = await fetchWithTimeout('/signon')
+  state.signonProfileData = await fetchWithTimeout('/me')
 }
 
 const getInitialData = async function () {

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -20,6 +20,10 @@ import {
 
 // dummy comment
 
+const signon = async function () {
+  state.signonProfileData = await fetchWithTimeout('/signon')
+}
+
 const getInitialData = async function () {
   console.log('retrieving taxons, locales and organisations')
   const apiResponse = await fetchWithTimeout('/get-init-data')
@@ -82,6 +86,7 @@ const fetchInitialData = async function () {
 
 const initWithoutHMR = async () => {
   initState()
+  await signon()
   await fetchInitialData()
   if (!state.systemErrorText) {
     setQueryParamsFromQS()

--- a/src/frontend/types/state-types.ts
+++ b/src/frontend/types/state-types.ts
@@ -1,5 +1,6 @@
 import { SearchParams } from '../../common/types/search-api-types'
 import { CSVDownloadType } from '../state'
+import { SignonProfileData } from '../../backend/constants/types'
 
 export type Field =
   | 'url'
@@ -52,4 +53,5 @@ export interface State {
   sorting: Partial<Record<Field, SortAction>>
   CSVDownloadType: CSVDownloadType
   phoneNumberError: boolean | null
+  signonProfileData?: SignonProfileData
 }

--- a/src/frontend/view/view.ts
+++ b/src/frontend/view/view.ts
@@ -77,6 +77,7 @@ const view = () => {
     dispatchCustomGAEvent('formSubmission', {
       formType: 'Search',
       formPosition: 'Page',
+      userOrganisation: state.signonProfileData.user.organisation_slug,
     })
     handleEvent({ type: EventType.Dom, id: 'search' })
   })


### PR DESCRIPTION
[Trello](https://trello.com/c/kitjOOPP/212-send-user-organisation-to-ga4)

We want to know how much usage there is of the app, per organisation, so we will
record the `organisation_slug` (from Signon authentication) in Google Analytics.

The tricky bit is to get the data out of the middleware, where authentication
takes place, into the browser, where data is sent to analytics.  This
implementation creates an API endpoint, guarded by the middleware auth process.
The middleware returns the user profile to the backend, which sends it via the
endpoint to the frontend.  The endpoint is only called once, when the site
is initialised.  This probably means that a user could sign out and back in with
a different identity, in which case GA would record the original identity, but
that situation seems unlikely.
