### PR TITLE
accessibility: grid tabbing

### DIFF
--- a/src/frontend/view/customURLCellRenderer.ts
+++ b/src/frontend/view/customURLCellRenderer.ts
@@ -18,35 +18,6 @@ export class URLCellRenderer {
     this.eGui.innerHTML = `<a class="govuk-link" key=${this.getUniqueKey()} href="${
       params.value
     }">${params.value}</a>`
-    this.registerEventsListeners()
-  }
-
-  registerEventsListeners() {
-    document.addEventListener('keydown', (event) => {
-      if (
-        !['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Tab'].includes(
-          event.key
-        )
-      ) {
-        return
-      }
-      const {
-        colDef: { field },
-        rowIndex,
-      } = this.params
-      const focusedCell = this.params.api.getFocusedCell()
-      if (
-        focusedCell?.column.getColId() === field &&
-        focusedCell?.rowIndex === rowIndex
-      ) {
-        const innerLink = document.querySelector(
-          `a[key="${this.getUniqueKey()}"]`
-        )
-        if (innerLink instanceof HTMLElement) {
-          innerLink.focus()
-        }
-      }
-    })
   }
 
   getUniqueKey = () => {

--- a/src/frontend/view/view-grid.ts
+++ b/src/frontend/view/view-grid.ts
@@ -75,9 +75,31 @@ const createAgGrid = () => {
     ...(sortConfig[field] || {}),
   }))
 
+  const suppressKeyboardEvent = (
+    params: SuppressKeyboardEventParams
+  ): boolean => {
+    return params.event.key.toUpperCase() === 'TAB'
+  }
+
+  const suppressHeaderKeyboardEvent = (params): boolean => {
+    const colNames = gridOptions.columnApi
+      .getAllDisplayedColumns()
+      .map((col) => col.colId)
+    const lastCol = colNames[colNames.length - 1]
+
+    return (
+      params.event.key.toUpperCase() === 'TAB' &&
+      params.column.getId() === lastCol
+    )
+  }
+
   const gridOptions = {
     rowData,
     columnDefs,
+    defaultColDef: {
+      suppressKeyboardEvent,
+      suppressHeaderKeyboardEvent,
+    },
     onPaginationChanged: function () {
       viewPagination(gridOptions)
     },


### PR DESCRIPTION
# Issue ID: DAC_Tab_Order_Issue-01


# The issue

On a grid or a table, accessibility users should be able to navigate the cells by using the `arrow` keys.
The `tab` keys should only focus on selectable elements in the document, such as links and button.

The accessibility testers noticed that the whole of the grid cells could be navigated with both `arrow` and `tab` keys, which is not the expected behaviour.


# Expected behaviour

- Tabbing should not navigate the cells
- Tabbing should select all the links and headers inside the grid, since they are interactive


# Solution

It is possible to override AgGrid's keyboard controls by specifying the methods `suppressKeyboardEvent` and `suppressHeaderKeyboardEvent` in the grid options.

In these methods, I am disabling the use of `tab` on the whole grid, except on the heads, which are clickable for sorting.

As a result, when tabbing in the grid, the default document behaviour will be used and not AgGrid's. You can see in the video that only links are being navigated when tabbing.


# Note

I had to rollback the custom cell component I had made a couple PRs ago. This component was aiming at automatically focusing on the link inside a cell, shall the cell contain one. Otherwise, accessibility users weren't able to open such links since the focus was on the "container cell".
However, it was making the behaviour inconsistent in conjunction with the `suppressKeyboardEvent` method used in this new PR.
It turns out that method solves all the issues, since "container cells" aren't selected at all anymore when tabbing.

When using arrow keys however, the container cell will still be selected, not the link inside. However, the user can then press the `tab` key, which will bring the focus to the link inside the container cell.
