### PR TITLE
fix: grid was empty when search results >10000

### DIFF
--- a/src/frontend/view/customAgGridHeader.ts
+++ b/src/frontend/view/customAgGridHeader.ts
@@ -113,7 +113,9 @@ export default class CustomAgGridHeader {
     // Ideally we'd update the query description via handleEvent(), but doing so
     // creates an infinite loop. Instead, we update the element directly.
     const description = document.getElementById('sort-description')
-    description.textContent = sortDescription(this.sortModel)
+    if (description) {
+      description.textContent = sortDescription(this.sortModel)
+    }
   }
 
   private get headerHtmlContent() {


### PR DESCRIPTION
Because the element with ID `sort-description` doesn't exist when there are more than 10K results, the custom header was throwing an error, which was interrupting the rendering of the grid early.

Just added a conditional.