### PR TITLE
Guilhemf/accessibility/cell outline

### DIFF
--- a/src/frontend/scss/grid.scss
+++ b/src/frontend/scss/grid.scss
@@ -1,6 +1,8 @@
 .ag-theme-alpine {
   margin-bottom: 30px;
   font-family: 'GDS Transport', arial, sans-serif;
+  --ag-input-focus-border-color: blue;
+  --ag-range-selection-border-color: blue;
 }
 
 #grid-wrapper {


### PR DESCRIPTION
# Issue ID: DAC _Non_Text_Contrast-01


# Before
<img width="505" alt="image" src="https://github.com/alphagov/govuk-knowledge-graph-search/assets/22219650/a64b1822-3517-40e8-87dc-f8ece7202896">
<img width="601" alt="image" src="https://github.com/alphagov/govuk-knowledge-graph-search/assets/22219650/6cfb97e6-7c4c-42a9-bcea-5b801f6f0883">



# After
<img width="575" alt="image" src="https://github.com/alphagov/govuk-knowledge-graph-search/assets/22219650/475bc861-f58a-498a-9b49-bc7e0b58effb">
<img width="594" alt="image" src="https://github.com/alphagov/govuk-knowledge-graph-search/assets/22219650/b858404c-02b8-4a93-88c9-07f0fc0aba0e">
