### PR TITLE
removed extra parameters from GTM script

### DIFF
--- a/src/backend/views/layouts/main.njk
+++ b/src/backend/views/layouts/main.njk
@@ -17,11 +17,11 @@
 {% block head %}
 {% if allowGoogleAnalytics %}
 <!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({"gtm.start":
-new Date().getTime(),event:"gtm.js"});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!="dataLayer"?"&l="+l:"";j.async=true;j.src=
-"https://www.googletagmanager.com/gtm.js?id="+i+dl+"&gtm_auth={{GTM_AUTH}}&gtm_preview=env-59&gtm_cookies_win=x";f.parentNode.insertBefore(j,f);
-})(window,document,"script","dataLayer","{{GTM_ID}}");</script>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','{{GTM_ID}}');</script>
 <!-- End Google Tag Manager -->
 {% endif %}
 <script src="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.js"></script>
@@ -58,7 +58,7 @@ j=d.createElement(s),dl=l!="dataLayer"?"&l="+l:"";j.async=true;j.src=
 {% block bodyStart %}
 {% if allowGoogleAnalytics %}
 <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{GTM_ID}}&gtm_auth={{GTM_AUTH}}&gtm_preview=env-59&gtm_cookies_win=x"
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{GTM_ID}}"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
 {% endif %}


### PR DESCRIPTION
GA tags broken and bot working correctly. Not sure why the extra params were added (back in June 2023). Possibly copied from GA tag manager somewhere. 
`&gtm_auth={{GTM_AUTH}}&gtm_preview=env-59&gtm_cookies_win=x`

Tags should be:
`<!-- Google Tag Manager -->
<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
'[https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f)](https://www.googletagmanager.com/gtm.js?id=%27+i+dl;f.parentNode.insertBefore(j,f));
})(window,document,'script','dataLayer','GTM-5LTHPJZ');</script>
<!-- End Google Tag Manager -->`

`<!-- Google Tag Manager (noscript) -->
<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5LTHPJZ"
height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
<!-- End Google Tag Manager (noscript) -->`