### PR TITLE
refactor: use only the 'search' dataset

### DIFF
--- a/src/backend/bigquery/bigquery.test.ts
+++ b/src/backend/bigquery/bigquery.test.ts
@@ -91,14 +91,14 @@ describe('[Function] sendInitQuery', () => {
     expect(BigQuery.prototype.query).toHaveBeenNthCalledWith(1, {
       query: `
         SELECT DISTINCT locale
-        FROM \`content.locale\`
+        FROM \`search.locale\`
         `,
       location: 'europe-west2',
       params: {},
     })
     expect(BigQuery.prototype.query).toHaveBeenNthCalledWith(2, {
       query: `
-        SELECT name
+        SELECT DISTINCT name
         FROM \`search.taxon\`
         `,
       location: 'europe-west2',
@@ -107,7 +107,7 @@ describe('[Function] sendInitQuery', () => {
     expect(BigQuery.prototype.query).toHaveBeenNthCalledWith(3, {
       query: `
         SELECT DISTINCT title
-        FROM \`graph.organisation\`
+        FROM \`search.organisation\`
         `,
       location: 'europe-west2',
       params: {},

--- a/src/backend/bigquery/bigquery.ts
+++ b/src/backend/bigquery/bigquery.ts
@@ -77,19 +77,19 @@ const sendInitQuery = async function (): Promise<InitResults> {
       await Promise.all([
         bigQuery(`
         SELECT DISTINCT locale
-        FROM \`content.locale\`
+        FROM \`search.locale\`
         `),
         bigQuery(`
-        SELECT name
+        SELECT DISTINCT name
         FROM \`search.taxon\`
         `),
         bigQuery(`
         SELECT DISTINCT title
-        FROM \`graph.organisation\`
+        FROM \`search.organisation\`
         `),
         bigQuery(`
         SELECT DISTINCT document_type
-        FROM \`content.document_type\`
+        FROM \`search.document_type\`
         `),
       ])
   } catch (error) {


### PR DESCRIPTION
Closes #63

Follows https://github.com/alphagov/govuk-knowledge-graph-gcp/pull/614

This allows permissions of the service account to be reduced to a single
BigQuery dataset.
