### PR TITLE
Don't sanitise form input

### DIFF
--- a/src/backend/utils/getParams.ts
+++ b/src/backend/utils/getParams.ts
@@ -9,51 +9,50 @@ import {
   PublishingStatus,
   PoliticalStatus,
 } from '../../common/types/search-api-types'
-import { sanitiseInput } from '../../common/utils/utils'
 
 export const getParams = (req: express.Request): SearchParams => {
   const searchType = <SearchType>(
-    (sanitiseInput(req.query[UrlParams.SearchType] as string) ||
+    ((req.query[UrlParams.SearchType] as string) ||
       SearchType.Keyword)
   )
   const selectedWords =
-    sanitiseInput(req.query[UrlParams.SelectedWords] as string) || ''
+    (req.query[UrlParams.SelectedWords] as string) || ''
   const excludedWords =
-    sanitiseInput(req.query[UrlParams.ExcludedWords] as string) || ''
-  const taxon = sanitiseInput(req.query[UrlParams.Taxon] as string) || ''
+    (req.query[UrlParams.ExcludedWords] as string) || ''
+  const taxon = (req.query[UrlParams.Taxon] as string) || ''
   const publishingOrganisation =
-    sanitiseInput(req.query[UrlParams.PublishingOrganisation] as string) || ''
-  const language = sanitiseInput(req.query[UrlParams.Language] as string) || ''
+    (req.query[UrlParams.PublishingOrganisation] as string) || ''
+  const language = (req.query[UrlParams.Language] as string) || ''
   const caseSensitive = req.query[UrlParams.CaseSensitive] === 'true'
   const combinator = <Combinator>(
-    (sanitiseInput(req.query[UrlParams.Combinator] as string) || Combinator.All)
+    ((req.query[UrlParams.Combinator] as string) || Combinator.All)
   )
   const documentType =
-    sanitiseInput(req.query[UrlParams.DocumentType] as string) || ''
+    (req.query[UrlParams.DocumentType] as string) || ''
 
   const keywordLocation =
-    (sanitiseInput(
+    ((
       req.query[UrlParams.KeywordLocation] as string
     ) as KeywordLocation) || KeywordLocation.All
 
   const publishingApplication = <PublishingApplication>(
-    (sanitiseInput(req.query[UrlParams.PublishingApplication] as string) ||
+    ((req.query[UrlParams.PublishingApplication] as string) ||
       PublishingApplication.Any)
   )
   const linkSearchUrl =
-    sanitiseInput(req.query[UrlParams.LinkSearchUrl] as string) || ''
+    (req.query[UrlParams.LinkSearchUrl] as string) || ''
   const phoneNumber =
-    sanitiseInput(req.query[UrlParams.PhoneNumber] as string) || ''
+    (req.query[UrlParams.PhoneNumber] as string) || ''
 
-  const publishingStatus = sanitiseInput(
+  const publishingStatus = (
     req.query[UrlParams.PublishingStatus] as string
   ) as PublishingStatus
   const politicalStatus = <PoliticalStatus>(
-    (sanitiseInput(req.query[UrlParams.PoliticalStatus] as string) ||
+    ((req.query[UrlParams.PoliticalStatus] as string) ||
       PoliticalStatus.Any)
   )
   const government =
-    sanitiseInput(req.query[UrlParams.Government] as string) || ''
+    (req.query[UrlParams.Government] as string) || ''
 
   return {
     searchType,

--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -7,28 +7,9 @@ const phoneUtil: PhoneNumberUtil = PhoneNumberUtil.getInstance()
 
 const id = (x: string): HTMLElement | null => document.getElementById(x)
 
-const tagBody = '(?:[^"\'>]|"[^"]*"|\'[^\']*\')*'
-
-const tagOrComment = new RegExp(
-  '<(?:' +
-    // Comment body.
-    '!--(?:(?:-*[^->])*--+|-?)' +
-    // Special "raw text" elements whose content should be elided.
-    '|script\\b' +
-    tagBody +
-    '>[\\s\\S]*?</script\\s*' +
-    '|style\\b' +
-    tagBody +
-    '>[\\s\\S]*?</style\\s*' +
-    // Regular name
-    '|/?[a-z]' +
-    tagBody +
-    ')>',
-  'gi'
-)
-
 const getFormInputValue = (inputId: string): string =>
-  sanitiseInput((<HTMLInputElement>id(inputId))?.value)
+  (<HTMLInputElement>id(inputId))?.value
+
 
 // TODO: Support many phone numbers at once.  Available distributions of
 // libphonenumber don't support this, so we would have to require users to
@@ -61,18 +42,6 @@ const parsePhoneNumber = function (phoneNumber: string): {
   }
 }
 
-const sanitiseInput = function (text: string | undefined): string {
-  // remove text that could lead to script injections
-  if (!text) return ''
-  text = text.trim()
-  let oldText: string
-  do {
-    oldText = text
-    text = text.replace(tagOrComment, '')
-  } while (text !== oldText)
-  return text.replace(/</g, '&lt;').replace(/""*/g, '"')
-}
-
 const sanitiseOutput = function (text: string): string {
   const escapeHTML = (str: string) => new Option(str).innerHTML
   return escapeHTML(text).replace(/'/g, '&apos;').replace(/"/g, '&quot;')
@@ -94,7 +63,6 @@ const splitKeywords = function (keywords: string): string[] {
 
 export {
   id,
-  sanitiseInput,
   sanitiseOutput,
   getFormInputValue,
   getPhoneNumber,


### PR DESCRIPTION
* SQL injection is mitigated by using BigQuery parameters.
* Any changes to the values of list-items break filtering, such as when
  trimming trailing whitespace from the title of https://www.gov.uk/api/content/government/organisations/department-for-levelling-up-housing-and-communities, which means that none of its publications appear in search results when filtering for that publishing organisation.
