### PR TITLE
fix: pin ag-grid-community version

### DIFF
--- a/src/backend/views/layouts/main.njk
+++ b/src/backend/views/layouts/main.njk
@@ -24,7 +24,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer','{{GTM_ID}}');</script>
 <!-- End Google Tag Manager -->
 {% endif %}
-<script src="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/ag-grid-community@31.3.2/dist/ag-grid-community.min.js" integrity="sha256-ULzU4/8xnTp9F6pbUw2GByUtsteCMTKi2W0+QNGuzwA=" crossorigin="anonymous"></script>
 
 <!--[if !IE 8]><!-->
 <link href="/main.css" rel="stylesheet" />


### PR DESCRIPTION
A new, major version 32.0.0 of ag-grid-community was recently published,
which removes a long-deprecated api that GovSearch uses to render its
table of search results. By pinning to the previous version, GovSearch
will continue to function. This is a temporary fix.
