### PR TITLE
Feat/hide search bar when in results page

### DIFF
--- a/src/frontend/view/view.ts
+++ b/src/frontend/view/view.ts
@@ -196,7 +196,7 @@ const viewMainLayout = () => {
     if (state.searchResults) {
       result.push(viewSearchResults())
     } else {
-    result.push(`
+      result.push(`
       <div class="govuk-grid-row simple-search">
         <div class="govuk-grid-column-two-thirds">
           ${viewSearchPanel()}


### PR DESCRIPTION
1.	Issue: Re-clicking “search” resets filters, confusing users.
2.	Reproduction: Filters are lost when re-clicking “search” after a query.
3.	Fix: Remove the search button and panel entirely.


**Before**

<img width="500" alt="image" src="https://github.com/user-attachments/assets/82f977c3-f1b4-45d6-beb0-c1b176daceff">





**After**
<img width="500" alt="Screenshot 2024-11-27 at 07 58 40" src="https://github.com/user-attachments/assets/bbe02162-2fa9-4991-996d-b69df94edb28">

<img width="500" alt="Screenshot 2024-11-27 at 07 58 53" src="https://github.com/user-attachments/assets/05d738c7-3d8c-4366-957e-22b12a0508b2">





