### PR TITLE
fix: IA-1609 - configure trust proxy setting to find requestor IP when behind GCP load-balancer

### DIFF
--- a/src/backend/app.ts
+++ b/src/backend/app.ts
@@ -125,8 +125,12 @@ class App {
         genid: generateSessionId,
       })
     )
-
-    this.app.set('trust proxy', 1) // trust first proxy
+    /*
+    'trust proxy' must be set to 2 when deployed behind GCP load-balancing in order to correctly identify
+    the requestor's IP address rather than that of the load-balancer. This is required for per-user rate-limiting.
+    See also - https://cloud.google.com/load-balancing/docs/https#x-forwarded-for_header
+    */
+    this.app.set('trust proxy', 2)
     this.app.use(passport.initialize())
     this.app.use(passport.session())
 


### PR DESCRIPTION
'trust proxy' must be set to 2 when deployed behind GCP load-balancing in order to correctly identify the requestor's IP address rather than that of the load-balancer. This is required for per-user rate-limiting. See also - https://cloud.google.com/load-balancing/docs/https#x-forwarded-for_header and https://express-rate-limit.mintlify.app/guides/troubleshooting-proxy-issues

Without this change the server is unable to differentiate requests between users as it sees all requests as coming from the load balancer. That would effectively mean a global rate-limit on all requests whereas we only want to apply rate-limiting based on the usage of each user individually.

I have tested this in the [dev env](https://govgraphsearchdev.dev/) across two devices. Previously, if one device reached the limit it would block access to all devices until the quota was replenished. It is now working as intended (requests from separate IPs have independent limits and do not affect each other). 