### PR TITLE
IA-1609: move setting the trust proxy to before middleware init

### DIFF
--- a/src/backend/app.ts
+++ b/src/backend/app.ts
@@ -29,6 +29,12 @@ class App {
   constructor(routes: Routes[]) {
     this.app = express()
     this.port = config.port
+    /*
+    'trust proxy' must be set to 2 when deployed behind GCP load-balancing in order to correctly identify
+    the requestor's IP address rather than that of the load-balancer. This is required for per-user rate-limiting.
+    See also - https://cloud.google.com/load-balancing/docs/https#x-forwarded-for_header
+    */
+    this.app.set('trust proxy', 2)
 
     this.initializeMiddlewares()
     this.initializeRoutes(routes)
@@ -125,12 +131,6 @@ class App {
         genid: generateSessionId,
       })
     )
-    /*
-    'trust proxy' must be set to 2 when deployed behind GCP load-balancing in order to correctly identify
-    the requestor's IP address rather than that of the load-balancer. This is required for per-user rate-limiting.
-    See also - https://cloud.google.com/load-balancing/docs/https#x-forwarded-for_header
-    */
-    this.app.set('trust proxy', 2)
     this.app.use(passport.initialize())
     this.app.use(passport.session())
 


### PR DESCRIPTION
How the trust proxy setting is read on app startup seems to vary between dev and staging. When deploying to staging the logging suggested `trust proxy` was undefined and defaulted to false. 

I have moved the setting earlier in the app startup process and tested it directly in staging. The logs no longer have the `trust proxy undefined` message and testing across two devices shows the intended behaviour.