### PR TITLE
ci: explicitly set required permissions on GitHub Actions Workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,4 +1,6 @@
 name: Lint GitHub Actions
+permissions:
+  contents: read
 on:
   push:
     paths: ['.github/**']

--- a/.github/workflows/check-code-hygiene.yml
+++ b/.github/workflows/check-code-hygiene.yml
@@ -1,5 +1,6 @@
 name: Code Hygiene
-
+permissions:
+  contents: read
 on:
   pull_request:
     branches:

--- a/.github/workflows/check-test-coverage.yml
+++ b/.github/workflows/check-test-coverage.yml
@@ -1,5 +1,4 @@
 name: Jest Coverage Check
-
 on:
   push:
     branches: [main]
@@ -10,6 +9,10 @@ jobs:
   test:
     name: Jest Test with Coverage Check
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      actions: write
 
     steps:
       - name: Check out code

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -1,5 +1,6 @@
 name: Deploy Production
-
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,5 +1,6 @@
 name: Deploy Staging
-
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
This addresses https://github.com/alphagov/govuk-knowledge-graph-search/security/code-scanning/1.